### PR TITLE
Tweak LoRA

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,11 @@ torchrun --nproc_per_node=x generate_<script_name>.py
 For full-parameter training on one node of 8 GPUs, run:
 
 ```bash
+# Eager attention
 accelerate launch --config_file zero3.yaml sft.py --config configs/sft_full.yaml
+
+# FlashAttention3
+accelerate launch --config_file zero3.yaml sft.py --config configs/sft_full.yaml --attn_implementation kernels-community/vllm-flash-attn3
 ```
 
 For LoRA training on one GPU, run:

--- a/configs/sft_lora.yaml
+++ b/configs/sft_lora.yaml
@@ -15,12 +15,10 @@ logging_steps: 1
 per_device_train_batch_size: 4
 gradient_accumulation_steps: 4
 use_peft: true
-lora_r: 2
-lora_alpha: 4
+lora_r: 8
+lora_alpha: 16
 lora_dropout: 0.0
-lora_target_parameters:
-- mlp.experts.down_proj
-- mlp.experts.gate_up_proj
+lora_target_modules: all-linear
 max_length: 4096
 warmup_ratio: 0.03
 lr_scheduler_type: cosine_with_min_lr


### PR DESCRIPTION
Use `all-linear` by default as this is more mem efficient and matches what we did in the cookbook